### PR TITLE
Call init() correctly when calling window.CoolClock()

### DIFF
--- a/coolclock.js
+++ b/coolclock.js
@@ -10,7 +10,7 @@
 
 // Constructor for CoolClock objects
 window.CoolClock = function(options) {
-	return this.init(options);
+	return CoolClock.prototype.init(options);
 }
 
 // Config contains some defaults, and clock skins


### PR DESCRIPTION
`Uncaught TypeError: Object [object Window] has no method 'init'`

'this' is the window object, not the CoolClock object.
