### PR TITLE
Work-around for "outer border - second hand line in IE" issue

### DIFF
--- a/coolclock.js
+++ b/coolclock.js
@@ -1,4 +1,3 @@
-
 // Constructor for CoolClock objects
 window.CoolClock = function(options) {
 	return this.init(options);
@@ -225,8 +224,8 @@ CoolClock.prototype = {
 		// Clear
 		this.ctx.clearRect(0,0,this.renderRadius*2,this.renderRadius*2);
 
-		// Draw the outer edge of the clock
-		if (skin.outerBorder)
+		// Draw the outer edge of the clock - not in IE
+		if (skin.outerBorder && !CoolClock.config.isIE)
 			this.fullCircleAt(this.renderRadius,this.renderRadius,skin.outerBorder);
 
 		// Draw the tick marks. Every 5th one is a big one

--- a/demos/demo.html
+++ b/demos/demo.html
@@ -4,7 +4,7 @@
 		<title>CoolClock Demo</title>
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
-		<!--[if IE]><script type="text/javascript" src="excanvas.js"></script><![endif]-->
+		<!--[if IE]><script type="text/javascript" src="../excanvas.js"></script><![endif]-->
 		<script src="../coolclock.js" type="text/javascript"></script>
 		<script src="../moreskins.js" type="text/javascript"></script>
 

--- a/demos/demo2.html
+++ b/demos/demo2.html
@@ -4,7 +4,7 @@
 		<title>CoolClock Demo 2</title>
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
-		<!--[if IE]><script type="text/javascript" src="excanvas.js"></script><![endif]-->
+		<!--[if IE]><script type="text/javascript" src="../excanvas.js"></script><![endif]-->
 		<script src="../coolclock.js" type="text/javascript"></script>
 		<script src="../moreskins.js" type="text/javascript"></script>
 

--- a/demos/logclock.html
+++ b/demos/logclock.html
@@ -4,7 +4,7 @@
 		<title>CoolClock Demo</title>
 
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
-		<!--[if IE]><script type="text/javascript" src="excanvas.js"></script><![endif]-->
+		<!--[if IE]><script type="text/javascript" src="../excanvas.js"></script><![endif]-->
 		<script src="../coolclock.js" type="text/javascript"></script>
 
 		<style type="text/css">


### PR DESCRIPTION
Hi,

![coolclock-issue-with-seconds-hand](https://f.cloud.github.com/assets/1184853/43525/1d1f04a4-568b-11e2-923d-c02a612a3546.gif)

The issue causing a line or shadow originiating from the 3 o'clock point following the second hand (or minute hand if lacking a second hand) as described on  https://github.com/simonbaird/CoolClock/issues/11 can be fixed (or rather worked around) by removing the outer border completely in IE. Just like the decorations...

Not a real fix but still rather effective :) as tested live in the CoolClock WordPress plugin http://wordpress.org/extend/plugins/coolclock/

Please include for 3+

Thanks!
