### PR TITLE
Run by reference time

### DIFF
--- a/demos/referenceTime.html
+++ b/demos/referenceTime.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+	<head>
+		<title>CoolClock using reference times</title>
+		<style type="text/css">
+			body { background-color:#ddd; }
+			.clock {
+				float:left; display:block; margin:10px; padding:10px; background-color:#fff;
+				-moz-box-shadow: 3px 3px 3px #999; -moz-border-radius:5px;
+				-webkit-box-shadow: 3px 3px 3px #999; -webkit-border-radius:5px;
+			}
+		</style>
+	</head>
+	<body>
+		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
+		<!--[if IE]><script type="text/javascript" src="excanvas.js"></script><![endif]-->
+		<script src="../coolclock.js" type="text/javascript"></script>
+		<script src="../moreskins.js" type="text/javascript"></script>
+		<script type="text/javascript">
+			$(function(){
+				$('body').append($('<canvas />', {
+					class: 'CoolClock:fancy:85:showSecondHand::1386309983000' // Friday, 06. December 2013 GMT 07:06
+				}));
+				CoolClock.findAndCreateClocks();
+			});
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
- Moved the options `showDigital`, `logClock` as well as `logClockRev` to the end of the options.
- Add config position 5: Reference time.
- Create new demo "referenceTime.html".
